### PR TITLE
feat: transform query to function_score

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahamove/pelias-client",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "files": [

--- a/src/transforms/elastic.transform.ts
+++ b/src/transforms/elastic.transform.ts
@@ -318,13 +318,18 @@ export class ElasticTransform {
       }
     }
     // if multiIndexOpts is provided, add extra scoring functions
-    if (multiIndexOpts) {
-      if (multiIndexOpts.extraFunctions) {
-        query.function_score = query.function_score || {}
-        query.function_score.functions = query.function_score.functions || []
-        query.function_score.functions.push(...multiIndexOpts.extraFunctions)
+    if (multiIndexOpts && multiIndexOpts.extraFunctions) {
+      if (!query.function_score) {
+          query = {
+              function_score: {
+                  query: query,
+                  functions: []
+              }
+          };
       }
-    }
+      query.function_score.functions = query.function_score.functions || [];
+      query.function_score.functions.push(...multiIndexOpts.extraFunctions);
+  }
     const sort = ElasticTransform.createSort({ sortScore, lat, lon })
     if (multiIndexOpts && multiIndexOpts.overwriteHits) {
       size = 0


### PR DESCRIPTION
When the search text contains only one word, the query body doesn't include a 'function_score' field. Therefore, we need to transform the query structure to include function_score.